### PR TITLE
ci(npm): Prepare for release via trusted publishers

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
     contents: read
+    id-token: write
 
 jobs:
     checks:
@@ -53,5 +54,3 @@ jobs:
 
             - name: Publish to npm
               run: npm publish --access public
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
[See](https://docs.npmjs.com/trusted-publishers)
