### PR TITLE
fix: Popup size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ export type AuthConfigurationInput = {
 };
 
 const DOMAIN_WINDOW_DEFAULT_URL = 'https://app.frontify.com/finder';
-const POPUP_DEFAULT_TITLE = 'Authorize Frontify';
 const POPUP_STATE = {
     open: false,
 };
@@ -38,15 +37,7 @@ export async function authorize(
         popup.close();
     }
 
-    popup = createPopUp(
-        popupConfiguration ?? {
-            title: POPUP_DEFAULT_TITLE,
-            width: 800,
-            height: 600,
-            top: 50,
-            left: 50,
-        },
-    );
+    popup = createPopUp(popupConfiguration ?? {});
 
     POPUP_STATE.open = true;
 


### PR DESCRIPTION
The previous bump to `DEFAULT_POPUP_CONFIG` in `Popup.ts` had no visible effect because `index.ts` was passing its own hardcoded fallback config (800×600) directly into `new Popup(...)` whenever the caller omitted popupConfiguration.

This PR replaces that fallback with `popupConfiguration ?? {}`, making `DEFAULT_POPUP_CONFIG` the single source of truth.

The popup has now the desired size which gives more space between the scopes container and the footer:
<img width="756" height="397" alt="Screenshot 2026-06-03 at 09 58 35" src="https://github.com/user-attachments/assets/68099d19-597b-4f91-8d5a-93d9dfb2aef2" />
